### PR TITLE
chore(types): loose color type for text component

### DIFF
--- a/packages/core/src/components/Text.ts
+++ b/packages/core/src/components/Text.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import chalk, { ForegroundColor } from 'chalk'
 import {
   PropType,
   h,
@@ -6,6 +6,7 @@ import {
   defineComponent,
   onUpdated,
 } from '@vue/runtime-core'
+import type { LiteralUnion } from 'type-fest'
 import type { Styles } from '../renderer/styles'
 import { scheduleUpdateSymbol } from '../injectionSymbols'
 import { colorize } from '../renderer/textColor'
@@ -17,8 +18,8 @@ export const defaultStyle: Styles = {
 }
 
 export interface TuiTextProps {
-  color?: string
-  bgColor?: string
+  color?: LiteralUnion<ForegroundColor, string>
+  bgColor?: LiteralUnion<ForegroundColor, string>
   dimmed?: boolean
   bold?: boolean
   italic?: boolean
@@ -32,8 +33,8 @@ export const TuiText = defineComponent({
   name: 'TuiText',
 
   props: {
-    color: String,
-    bgColor: String,
+    color: String as PropType<LiteralUnion<ForegroundColor, string>>,
+    bgColor: String as PropType<LiteralUnion<ForegroundColor, string>>,
     dimmed: Boolean,
     bold: Boolean,
     italic: Boolean,

--- a/packages/core/src/components/Text.ts
+++ b/packages/core/src/components/Text.ts
@@ -6,7 +6,7 @@ import {
   defineComponent,
   onUpdated,
 } from '@vue/runtime-core'
-import type { LiteralUnion } from 'type-fest'
+import type { LiteralUnion } from '../utils'
 import type { Styles } from '../renderer/styles'
 import { scheduleUpdateSymbol } from '../injectionSymbols'
 import { colorize } from '../renderer/textColor'

--- a/packages/core/src/components/Text.ts
+++ b/packages/core/src/components/Text.ts
@@ -1,4 +1,4 @@
-import chalk, { ForegroundColor } from 'chalk'
+import chalk from 'chalk'
 import {
   PropType,
   h,
@@ -17,8 +17,8 @@ export const defaultStyle: Styles = {
 }
 
 export interface TuiTextProps {
-  color?: ForegroundColor
-  bgColor?: ForegroundColor
+  color?: string
+  bgColor?: string
   dimmed?: boolean
   bold?: boolean
   italic?: boolean
@@ -32,8 +32,8 @@ export const TuiText = defineComponent({
   name: 'TuiText',
 
   props: {
-    color: String as PropType<ForegroundColor>,
-    bgColor: String as PropType<ForegroundColor>,
+    color: String,
+    bgColor: String,
     dimmed: Boolean,
     bold: Boolean,
     italic: Boolean,


### PR DESCRIPTION
This change is to ensure that the Hex color type works fine.
<img width="678" alt="test111" src="https://user-images.githubusercontent.com/22515951/188664520-8b4d89f5-e96e-43ea-b53c-15ae1ba09782.png">
