### PR TITLE
chore: rename the recommended vscode extension (#11) [skip ci]

### DIFF
--- a/packages/create-vue-termui/template-ts/.vscode/extensions.json
+++ b/packages/create-vue-termui/template-ts/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar"]
+  "recommendations": ["vue.volar"]
 }

--- a/packages/create-vue-termui/template-ts/.vscode/extensions.json
+++ b/packages/create-vue-termui/template-ts/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["vue.volar"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
`johnsoncodehk.volar` has been renamed to `vue.volar`