### PR TITLE
chore: upgrade deps

### DIFF
--- a/packages/create-vue-termui/template-ts/package.json
+++ b/packages/create-vue-termui/template-ts/package.json
@@ -11,19 +11,19 @@
     "build": "vtui build"
   },
   "dependencies": {
-    "vue": "^3.2.31",
-    "@vue/runtime-core": "^3.2.31",
+    "@vue/runtime-core": "^3.2.41",
+    "vue": "^3.2.41",
     "vue-termui": "*"
   },
   "devDependencies": {
-    "@types/node": "^16.0.0",
-    "@vue/compiler-sfc": "^3.2.31",
+    "@types/node": "^18.11.3",
+    "@vitejs/plugin-vue": "^3.1.2",
     "@vue-termui/cli": "*",
-    "@vitejs/plugin-vue": "^2.2.4",
-    "typescript": "^4.5.4",
-    "unplugin-auto-import": "^0.6.1",
-    "unplugin-vue-components": "^0.18.0",
-    "vite": "^3.1.3",
+    "@vue/compiler-sfc": "^3.2.41",
+    "typescript": "^4.8.4",
+    "unplugin-auto-import": "^0.11.2",
+    "unplugin-vue-components": "^0.22.8",
+    "vite": "^3.1.8",
     "vite-plugin-vue-termui": "*"
   }
 }


### PR DESCRIPTION
Project created by `pnpm create vue-termui` will report errors when in dev mode like this: 
<img width="675" alt="image" src="https://user-images.githubusercontent.com/38490578/197372515-96b0e816-4499-47d7-9587-2286320b7b20.png">

After upgrade `unplugin-vue-components` to `0.22.8`, It's normal.

So I think the template's `package.json` need upgrade.
