### PR TITLE
fix(core): should external `terminal-link` when build

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         'widest-line',
         'wrap-ansi',
         'yoga-layout',
+        'terminal-link',
         'yoga-layout-prebuilt',
         'ws',
       ],


### PR DESCRIPTION
Closes #19 