### PR TITLE
feat: add TextTable component

### DIFF
--- a/docs/components/box.md
+++ b/docs/components/box.md
@@ -67,15 +67,15 @@ Both `margin` and `padding` expand into per-axis and per-side shorthands:
 
 ## Appearance
 
-| Prop                 | Type                                                             | Description                  |
-| -------------------- | ---------------------------------------------------------------- | ---------------------------- |
-| `backgroundColor`    | `ColorInput`                                                     | Fill color                   |
-| `border`             | `boolean`                                                        | Draw a border                |
-| `borderStyle`        | `'single'` \| `'double'` \| `'rounded'` \| `'heavy'` \| `'none'` | Border preset                |
-| `borderColor`        | `ColorInput`                                                     | Border color                 |
-| `focusedBorderColor` | `ColorInput`                                                     | Border color while focused   |
-| `title`              | `string`                                                         | Text shown in the top border |
-| `titleAlignment`     | `'left'` \| `'center'` \| `'right'`                              | Title position               |
+| Prop                 | Type                                                 | Description                                            |
+| -------------------- | ---------------------------------------------------- | ------------------------------------------------------ |
+| `backgroundColor`    | `ColorInput`                                         | Fill color                                             |
+| `border`             | `boolean`                                            | Draw a border                                          |
+| `borderStyle`        | `'single'` \| `'double'` \| `'rounded'` \| `'heavy'` | Border preset (hide the border with `:border="false"`) |
+| `borderColor`        | `ColorInput`                                         | Border color                                           |
+| `focusedBorderColor` | `ColorInput`                                         | Border color while focused                             |
+| `title`              | `string`                                             | Text shown in the top border                           |
+| `titleAlignment`     | `'left'` \| `'center'` \| `'right'`                  | Title position                                         |
 
 `ColorInput` is a hex/name string or an OpenTUI `RGBA` instance.
 

--- a/playground/src/components/Sidebar.vue
+++ b/playground/src/components/Sidebar.vue
@@ -57,6 +57,7 @@ const items = [
   { label: 'Notifications', to: '/demos/notifications' },
   { label: 'Terminal title', to: '/demos/terminal-title' },
   { label: 'Text selection', to: '/demos/text-selection' },
+  { label: 'Text table', to: '/demos/text-table' },
   { label: 'Fractal (3D)', to: '/demos/fractal' },
   { label: 'Draggable cube (3D)', to: '/demos/draggable-cube' },
   { label: 'Shader cube (3D)', to: '/demos/shader-cube' },

--- a/playground/src/pages/demos/text-table.vue
+++ b/playground/src/pages/demos/text-table.vue
@@ -1,0 +1,361 @@
+<script setup lang="ts">
+// Ported from opentui packages/examples/src/text-table-demo.ts
+import {
+  bold,
+  Box,
+  computed,
+  fg,
+  onKeyDown,
+  onScopeDispose,
+  ref,
+  ScrollBox,
+  t,
+  TableCell,
+  TableRow,
+  Text,
+  TextTable,
+  useRenderer,
+  useTemplateRef,
+} from 'vue-termui'
+import type { BorderStyle } from 'vue-termui'
+
+// Chunk helpers shared with the original demo's datasets.
+type TextChunk = ReturnType<typeof bold>
+function cell(text: string): TextChunk[] {
+  return [{ __isChunk: true, text }]
+}
+
+const PALETTE = {
+  panel: '#0d0d0d',
+  text: '#f0f0f0',
+  muted: '#666666',
+  soft: '#bbbbbb',
+  rose: '#e8c97a',
+  ember: '#b8a0ff',
+  flame: '#ffffff',
+  eye: '#00d4aa',
+  border: '#2a2a2a',
+} as const
+
+const WRAP_MODES = ['none', 'word', 'char'] as const
+const BORDER_STYLES: BorderStyle[] = ['single', 'rounded', 'double', 'heavy']
+const COLUMN_WIDTH_MODES = ['content', 'full'] as const
+const COLUMN_FITTERS = ['proportional', 'balanced'] as const
+const CELL_PADDING_VALUES = [0, 1, 2]
+
+const primaryContentSets: TextChunk[][][][] = [
+  [
+    [[bold('Service')], [bold('Status')], [bold('Notes')]],
+    [cell('api'), [fg(PALETTE.eye)('OK')], [fg(PALETTE.muted)('latency'), ...cell(' 28ms')]],
+    [cell('worker'), [fg(PALETTE.ember)('DEGRADED')], cell('queue depth: 124')],
+    [cell('billing'), [fg(PALETTE.flame)('ERROR')], cell('retrying payment provider')],
+  ],
+  [
+    [[bold('Region')], [bold('Requests')], [bold('Trend')]],
+    [cell('us-east-1'), cell('1.2M'), [fg(PALETTE.eye)('+12.4%')]],
+    [cell('eu-west-1'), cell('890K'), [fg(PALETTE.soft)('+5.1%')]],
+    [cell('ap-south-1'), cell('540K'), [fg(PALETTE.flame)('-2.0%')]],
+  ],
+  [
+    [[bold('Task')], [bold('Owner')], [bold('ETA')]],
+    [
+      cell(
+        'Wrap regression in operational status dashboard with dynamic row heights and constrained layout validation',
+      ),
+      cell('core platform and runtime reliability squad'),
+      [
+        fg(PALETTE.eye)(
+          'done after validating none, word, and char wrap modes across narrow, medium, wide, and ultra-wide terminal widths',
+        ),
+      ],
+    ],
+    [
+      cell(
+        'Unicode layout stabilization for mixed Latin, punctuation, symbols, and long identifiers in adjacent columns',
+      ),
+      cell('render pipeline maintainers with fallback shaping support'),
+      cell(
+        'in review with follow-up checks for border style transitions, cell padding variants, and selection range consistency',
+      ),
+    ],
+    [
+      cell(
+        'Snapshot pass for table rendering in content mode and full mode with heavy and double border combinations',
+      ),
+      cell('qa automation and visual diff triage group'),
+      cell(
+        'today pending final baseline updates for oversized fixtures that intentionally stress wrapping behavior on high-resolution terminals',
+      ),
+    ],
+    [
+      cell(
+        'Document edge cases where long tokens without spaces force char wrapping and reveal per-cell clipping regressions',
+      ),
+      cell('developer experience and docs tooling'),
+      cell(
+        'planned for this sprint once final reproducible examples are captured and linked to regression tracking tickets',
+      ),
+    ],
+    [
+      cell(
+        'Performance sweep of wrapping algorithm under large datasets to confirm stable frame times during rapid key toggling',
+      ),
+      cell('runtime performance task force'),
+      cell(
+        'scheduled after review, with benchmark runs on laptop and desktop terminals at 200-plus column widths',
+      ),
+    ],
+  ],
+]
+
+const unicodeContentSets: TextChunk[][][][] = [
+  [
+    [[bold('Locale')], [bold('Sample')]],
+    [cell('ja-JP'), cell('東京の夜景と絵文字 🌃✨')],
+    [cell('zh-CN'), cell('你好世界，布局检查中 🚀')],
+    [cell('ko-KR'), cell('한글과 이모지 조합 테스트 😄')],
+  ],
+  [
+    [[bold('Expression')], [bold('Meaning')]],
+    [cell('山川异域'), cell('Different lands, shared sky 🌏')],
+    [cell('꽃길만 걷자'), cell('Walk only flower paths 🌸')],
+    [cell('加油'), cell('Keep pushing forward 💪')],
+  ],
+  [
+    [[bold('Column')], [bold('Wrapped Text')]],
+    [
+      cell('mixed-languages'),
+      cell(
+        'CJK and emoji wrapping stress case: こんにちは世界 and 안녕하세요 세계 and 你好，世界 followed by long English prose that keeps flowing to test whether each cell wraps naturally even when the terminal is extremely wide and the row still needs multiple visual lines for readability 🌍🚀',
+      ),
+    ],
+    [
+      cell('emoji-and-symbols'),
+      cell(
+        'Faces 😀😃😄😁😆 plus symbols 🧪📦🛰️🔧📊 mixed with version tags like release-candidate-build-2026-02-very-long-token-without-breaks to ensure char wrapping remains stable and no glyph alignment issues appear at column boundaries',
+      ),
+    ],
+    [
+      cell('long-cjk-phrase'),
+      cell(
+        '長文の日本語テキストと中文段落和한국어문장을連続して配置し、その後に additional English context describing renderer behavior, border intersection handling, and selection extraction so that this single cell remains a reliable wrapping torture test.',
+      ),
+    ],
+    [
+      cell('mixed-punctuation'),
+      cell(
+        'Wrap behavior with punctuation-heavy content: [alpha]{beta}(gamma)<delta>|epsilon| then repeated fragments, commas, semicolons, and slashes to verify token boundaries do not break border drawing logic or spacing consistency in neighboring columns.',
+      ),
+    ],
+  ],
+]
+
+const contentIndex = ref(0)
+const wrapIndex = ref(1)
+const borderIndex = ref(0)
+const columnWidthModeIndex = ref(0)
+const columnFitterIndex = ref(0)
+const cellPaddingIndex = ref(0)
+const borderEnabled = ref(true)
+const outerBorderEnabled = ref(true)
+const showBordersEnabled = ref(true)
+
+const wrapMode = computed(() => WRAP_MODES[wrapIndex.value] ?? 'word')
+const borderStyle = computed(() => BORDER_STYLES[borderIndex.value] ?? 'single')
+const columnWidthMode = computed(() => COLUMN_WIDTH_MODES[columnWidthModeIndex.value] ?? 'content')
+const columnFitter = computed(() => COLUMN_FITTERS[columnFitterIndex.value] ?? 'proportional')
+const cellPadding = computed(() => CELL_PADDING_VALUES[cellPaddingIndex.value] ?? 0)
+
+// The primary table is rendered declaratively with <TableRow>/<TableCell>;
+// the unicode table takes the raw content matrix like the original demo.
+const primaryContent = computed(
+  () => primaryContentSets[contentIndex.value] ?? primaryContentSets[0]!,
+)
+const unicodeContent = computed(
+  () => unicodeContentSets[contentIndex.value] ?? unicodeContentSets[0]!,
+)
+
+const controlsContent = computed(
+  () => t`${bold('TextTable Demo')}  ${fg(PALETTE.muted)('1/2/3 dataset • W wrap • B style • M width • F fitter • P padding • N inner • O outer • H draw • drag to select • C clear')}
+Current: dataset ${fg(PALETTE.soft)(String(contentIndex.value + 1))} | wrap ${fg(PALETTE.rose)(wrapMode.value)} | style ${fg(PALETTE.ember)(borderStyle.value)} | width ${fg(PALETTE.eye)(columnWidthMode.value)} | fitter ${fg(PALETTE.rose)(columnFitter.value)} | padding ${fg(PALETTE.soft)(String(cellPadding.value))} | inner ${fg(PALETTE.rose)(borderEnabled.value ? 'on' : 'off')} | outer ${fg(PALETTE.ember)(outerBorderEnabled.value ? 'on' : 'off')} | draw ${fg(PALETTE.eye)(showBordersEnabled.value ? 'on' : 'off')}`,
+)
+
+// Selection status panel
+const renderer = useRenderer()
+const selectionMeta = ref('No selection yet')
+const selectionText = ref('')
+const selectionScroll = useTemplateRef('selectionScroll')
+
+function clearSelectionStatus(message: string) {
+  selectionMeta.value = message
+  selectionText.value = ''
+  if (selectionScroll.value) selectionScroll.value.$el.scrollTop = 0
+}
+
+const selectionHandler = () => {
+  const selectedText = renderer.getSelection()?.getSelectedText()
+  if (!selectedText) {
+    clearSelectionStatus('Empty selection')
+    return
+  }
+
+  const lines = selectedText.split('\n').length
+  selectionMeta.value = `Selected ${lines} line${lines === 1 ? '' : 's'} (${selectedText.length} chars)`
+  selectionText.value = selectedText
+  if (selectionScroll.value) selectionScroll.value.$el.scrollTop = 0
+}
+renderer.on('selection', selectionHandler)
+onScopeDispose(() => {
+  renderer.off('selection', selectionHandler)
+  renderer.clearSelection()
+})
+
+onKeyDown((key) => {
+  if (key.ctrl || key.meta) return
+
+  if (key.name === '1' || key.name === '2' || key.name === '3') {
+    contentIndex.value = Number(key.name) - 1
+  } else if (key.name === 'w') {
+    wrapIndex.value = (wrapIndex.value + 1) % WRAP_MODES.length
+  } else if (key.name === 'b') {
+    borderIndex.value = (borderIndex.value + 1) % BORDER_STYLES.length
+  } else if (key.name === 'm') {
+    columnWidthModeIndex.value = (columnWidthModeIndex.value + 1) % COLUMN_WIDTH_MODES.length
+  } else if (key.name === 'f') {
+    columnFitterIndex.value = (columnFitterIndex.value + 1) % COLUMN_FITTERS.length
+  } else if (key.name === 'p') {
+    cellPaddingIndex.value = (cellPaddingIndex.value + 1) % CELL_PADDING_VALUES.length
+  } else if (key.name === 'n') {
+    borderEnabled.value = !borderEnabled.value
+  } else if (key.name === 'o') {
+    outerBorderEnabled.value = !outerBorderEnabled.value
+  } else if (key.name === 'h') {
+    showBordersEnabled.value = !showBordersEnabled.value
+  } else if (key.name === 'c') {
+    renderer.clearSelection()
+    clearSelectionStatus('Selection cleared')
+  }
+})
+</script>
+
+<template>
+  <Box width="100%" height="100%" flexDirection="column" :padding="1" :gap="1">
+    <ScrollBox
+      width="100%"
+      :flexGrow="1"
+      :flexShrink="1"
+      scrollY
+      :border="false"
+      :verticalScrollbarOptions="{ visible: false }"
+      :contentOptions="{ flexDirection: 'column', gap: 1 }"
+    >
+      <Text :fg="PALETTE.text" wrapMode="word" :selectable="false" :content="controlsContent" />
+
+      <Text :fg="PALETTE.ember" :selectable="false" :content="t`${bold('Operational Table')}`" />
+      <TextTable
+        width="100%"
+        :wrapMode="wrapMode"
+        :columnWidthMode="columnWidthMode"
+        :columnFitter="columnFitter"
+        :cellPadding="cellPadding"
+        :border="borderEnabled"
+        :outerBorder="outerBorderEnabled"
+        :showBorders="showBordersEnabled"
+        :borderStyle="borderStyle"
+        :borderColor="PALETTE.rose"
+        :fg="PALETTE.text"
+      >
+        <TableRow v-for="(row, rowIdx) in primaryContent" :key="rowIdx">
+          <TableCell v-for="(chunks, colIdx) in row" :key="colIdx" :content="chunks" />
+        </TableRow>
+      </TextTable>
+
+      <Text
+        :fg="PALETTE.rose"
+        :selectable="false"
+        :content="t`${bold('Unicode/CJK/Emoji Table')}`"
+      />
+      <TextTable
+        width="100%"
+        :content="unicodeContent"
+        :wrapMode="wrapMode"
+        :columnWidthMode="columnWidthMode"
+        :columnFitter="columnFitter"
+        :cellPadding="cellPadding"
+        :border="borderEnabled"
+        :outerBorder="outerBorderEnabled"
+        :showBorders="showBordersEnabled"
+        :borderStyle="borderStyle"
+        :borderColor="PALETTE.rose"
+        :fg="PALETTE.text"
+      />
+
+      <Text
+        :fg="PALETTE.eye"
+        :selectable="false"
+        :content="
+          t`${bold('Static Table')} ${fg(PALETTE.muted)('(declarative <TableRow>/<TableCell>, unaffected by the toggles)')}`
+        "
+      />
+      <!-- Row styles cascade to every cell; cell props and content chunks win. -->
+      <TextTable
+        borderStyle="rounded"
+        :borderColor="PALETTE.eye"
+        :cellPadding="1"
+        columnWidthMode="content"
+        :fg="PALETTE.text"
+      >
+        <TableRow bold :fg="PALETTE.eye">
+          <TableCell>Package</TableCell>
+          <TableCell>Version</TableCell>
+          <TableCell>Status</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>vue-termui</TableCell>
+          <TableCell dim>0.1.0</TableCell>
+          <TableCell fg="#7ee787">stable</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>@vue-termui/three</TableCell>
+          <TableCell dim>0.2.3</TableCell>
+          <TableCell :content="t`${fg('#f1e05a')('beta')} ${fg(PALETTE.muted)('(3D)')}`" />
+        </TableRow>
+        <TableRow dim italic>
+          <TableCell>legacy-renderer</TableCell>
+          <TableCell>0.0.9</TableCell>
+          <TableCell strikethrough>deprecated</TableCell>
+        </TableRow>
+      </TextTable>
+    </ScrollBox>
+
+    <Box
+      width="100%"
+      :height="10"
+      :flexGrow="0"
+      :flexShrink="0"
+      border
+      borderStyle="double"
+      :borderColor="PALETTE.border"
+      title="Selected Text"
+      titleAlignment="left"
+      :padding="1"
+      :backgroundColor="PALETTE.panel"
+      flexDirection="column"
+    >
+      <Text :fg="PALETTE.eye" :selectable="false">{{ selectionMeta }}</Text>
+      <ScrollBox
+        ref="selectionScroll"
+        width="100%"
+        :flexGrow="1"
+        :flexShrink="1"
+        scrollY
+        :border="false"
+        :verticalScrollbarOptions="{ visible: false }"
+      >
+        <Text :fg="PALETTE.text" wrapMode="word" width="100%" :selectable="false">
+          {{ selectionText }}
+        </Text>
+      </ScrollBox>
+    </Box>
+  </Box>
+</template>

--- a/src/components/TextTable.spec.ts
+++ b/src/components/TextTable.spec.ts
@@ -1,0 +1,292 @@
+// @vitest-environment node
+import { TextAttributes, TextTableRenderable, fg, parseColor } from '@opentui/core'
+import { createTestRenderer } from '@opentui/core/testing'
+import { createRenderer, h, nextTick, ref } from '@vue/runtime-core'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createNodeOps } from '../renderer/nodeOps'
+import { TableCell, TableRow, TextTable } from './TextTable'
+import type { Renderable, TextChunk, TextTableContent } from '@opentui/core'
+import type { TestRendererSetup } from '@opentui/core/testing'
+import type { VNode } from '@vue/runtime-core'
+
+describe('TextTable', () => {
+  let test: TestRendererSetup
+  let render: (vnode: VNode | null, container: Renderable) => void
+
+  beforeEach(async () => {
+    test = await createTestRenderer({ width: 60, height: 20 })
+    render = createRenderer(createNodeOps(test.renderer)).render
+  })
+
+  afterEach(() => {
+    test.renderer.destroy()
+  })
+
+  function mountedTable(): TextTableRenderable {
+    return test.renderer.root.getChildren()[0] as TextTableRenderable
+  }
+
+  function chunk(text: string): TextChunk[] {
+    return [{ __isChunk: true, text }]
+  }
+
+  it('renders a TextTableRenderable from the content prop', async () => {
+    const content: TextTableContent = [
+      [chunk('Service'), chunk('Status')],
+      [chunk('api'), chunk('OK')],
+    ]
+    render(h(TextTable, { content }), test.renderer.root)
+    await test.renderOnce()
+
+    const table = mountedTable()
+    expect(table).toBeInstanceOf(TextTableRenderable)
+    expect(table.content).toBe(content)
+    const frame = test.captureCharFrame()
+    expect(frame).toContain('Service')
+    expect(frame).toContain('api')
+    // borders are on by default
+    expect(frame).toContain('│')
+  })
+
+  it('forwards table options to the renderable', async () => {
+    render(
+      h(TextTable, {
+        content: [[chunk('a')]],
+        wrapMode: 'char',
+        borderStyle: 'double',
+        columnWidthMode: 'content',
+        columnFitter: 'balanced',
+        cellPadding: 2,
+      }),
+      test.renderer.root,
+    )
+    await test.renderOnce()
+
+    const table = mountedTable()
+    expect(table.wrapMode).toBe('char')
+    expect(table.borderStyle).toBe('double')
+    expect(table.columnWidthMode).toBe('content')
+    expect(table.columnFitter).toBe('balanced')
+    expect(table.cellPadding).toBe(2)
+  })
+
+  describe('boolean props', () => {
+    it('keeps the renderable defaults when unset', async () => {
+      render(h(TextTable, { content: [[chunk('a')]] }), test.renderer.root)
+      await test.renderOnce()
+
+      const table = mountedTable()
+      expect(table.border).toBe(true)
+      expect(table.outerBorder).toBe(true)
+      expect(table.showBorders).toBe(true)
+    })
+
+    it('forwards explicit false values', async () => {
+      render(
+        h(TextTable, {
+          content: [[chunk('a')]],
+          border: false,
+          outerBorder: false,
+          showBorders: false,
+        }),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const table = mountedTable()
+      expect(table.border).toBe(false)
+      expect(table.outerBorder).toBe(false)
+      expect(table.showBorders).toBe(false)
+      expect(test.captureCharFrame()).not.toContain('│')
+    })
+
+    it('reads bare attributes as true', async () => {
+      render(
+        // bare attributes (`<TextTable border>`) arrive as empty strings
+        h(TextTable, {
+          content: [[chunk('a')]],
+          border: '' as unknown as boolean,
+          showBorders: '' as unknown as boolean,
+        }),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const table = mountedTable()
+      expect(table.border).toBe(true)
+      expect(table.showBorders).toBe(true)
+    })
+  })
+
+  describe('declarative rows and cells', () => {
+    it('builds the table content from TableRow/TableCell slots', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, null, () => [
+            h(TableCell, null, () => 'Service'),
+            h(TableCell, null, () => 'Status'),
+          ]),
+          h(TableRow, null, () => [
+            h(TableCell, null, () => 'api'),
+            h(TableCell, null, () => 'OK'),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const table = mountedTable()
+      expect(table.content).toHaveLength(2)
+      expect(table.content[0]).toHaveLength(2)
+      const frame = test.captureCharFrame()
+      expect(frame).toContain('Service')
+      expect(frame).toContain('api')
+      expect(frame).toContain('OK')
+    })
+
+    it('applies cell style props as chunk styles', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, null, () => [
+            h(TableCell, { bold: true }, () => 'Service'),
+            h(TableCell, { fg: '#00d4aa' }, () => 'OK'),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const [row] = mountedTable().content
+      const boldChunk = row![0]![0]!
+      expect(boldChunk.text).toBe('Service')
+      expect(boldChunk.attributes! & TextAttributes.BOLD).toBe(TextAttributes.BOLD)
+      const coloredChunk = row![1]![0]!
+      expect(coloredChunk.fg).toEqual(parseColor('#00d4aa'))
+    })
+
+    it('cascades row style props to every cell', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, { bold: true, fg: '#ff0000' }, () => [
+            h(TableCell, null, () => 'Service'),
+            h(TableCell, null, () => 'Status'),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const [row] = mountedTable().content
+      for (const cellChunks of row!) {
+        const chunk = cellChunks![0]!
+        expect(chunk.attributes! & TextAttributes.BOLD).toBe(TextAttributes.BOLD)
+        expect(chunk.fg).toEqual(parseColor('#ff0000'))
+      }
+    })
+
+    it('lets cell style props win over row style props', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, { fg: '#ff0000', bold: true }, () => [
+            h(TableCell, { fg: '#00ff00', italic: true }, () => 'OK'),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const chunk = mountedTable().content[0]![0]![0]!
+      // cell color wins, attributes merge
+      expect(chunk.fg).toEqual(parseColor('#00ff00'))
+      expect(chunk.attributes! & TextAttributes.BOLD).toBe(TextAttributes.BOLD)
+      expect(chunk.attributes! & TextAttributes.ITALIC).toBe(TextAttributes.ITALIC)
+    })
+
+    it('keeps chunk-level styles over row and cell styles', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, { fg: '#ff0000' }, () => [
+            h(TableCell, { fg: '#00ff00', content: fg('#0000ff')('chunk wins') }),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      expect(mountedTable().content[0]![0]![0]!.fg).toEqual(parseColor('#0000ff'))
+    })
+
+    it('accepts styled chunks through the cell content prop', async () => {
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, null, () => [h(TableCell, { content: fg('#b8a0ff')('DEGRADED') })]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      const cellChunks = mountedTable().content[0]![0]!
+      expect(cellChunks[0]!.text).toBe('DEGRADED')
+      expect(cellChunks[0]!.fg).toEqual(parseColor('#b8a0ff'))
+      expect(test.captureCharFrame()).toContain('DEGRADED')
+    })
+
+    it('supports v-for style fragments of rows', async () => {
+      const rows = ['one', 'two', 'three']
+      render(
+        h(TextTable, null, () =>
+          rows.map((label) => h(TableRow, { key: label }, () => [h(TableCell, null, () => label)])),
+        ),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+
+      expect(mountedTable().content).toHaveLength(3)
+      const frame = test.captureCharFrame()
+      expect(frame).toContain('one')
+      expect(frame).toContain('three')
+    })
+
+    it('updates the table when slot content changes', async () => {
+      const status = ref('OK')
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, null, () => [
+            h(TableCell, null, () => 'api'),
+            h(TableCell, null, () => status.value),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+      expect(test.captureCharFrame()).toContain('OK')
+
+      status.value = 'DOWN'
+      await nextTick()
+      await test.renderOnce()
+      expect(test.captureCharFrame()).toContain('DOWN')
+    })
+
+    it('keeps unchanged cell chunk references stable across re-renders', async () => {
+      const status = ref('OK')
+      render(
+        h(TextTable, null, () => [
+          h(TableRow, null, () => [
+            h(TableCell, null, () => 'api'),
+            h(TableCell, null, () => status.value),
+          ]),
+        ]),
+        test.renderer.root,
+      )
+      await test.renderOnce()
+      const before = mountedTable().content[0]![0]
+
+      status.value = 'DOWN'
+      await nextTick()
+      await test.renderOnce()
+
+      // the untouched cell keeps its identity so OpenTUI's cell diff skips it
+      expect(mountedTable().content[0]![0]).toBe(before)
+    })
+  })
+})

--- a/src/components/TextTable.ts
+++ b/src/components/TextTable.ts
@@ -1,0 +1,436 @@
+import {
+  createTextAttributes,
+  isStyledText,
+  parseColor,
+  type ColorInput,
+  type RGBA,
+  type StyledText,
+  type TextChunk,
+  type TextTableCellContent,
+  type TextTableContent,
+  type TextTableOptions,
+  type TextTableRenderable,
+} from '@opentui/core'
+import {
+  Comment,
+  Fragment,
+  Text as TextVNode,
+  defineComponent,
+  h,
+  isVNode,
+  onMounted,
+  shallowRef,
+  warn,
+  type FunctionalComponent,
+  type VNode,
+  type VNodeArrayChildren,
+} from '@vue/runtime-core'
+import {
+  optionalBooleanProps,
+  renderableEmits,
+  renderableProps,
+  setupRenderableEvents,
+  type RenderableEventProps,
+  type TuiComponent,
+} from './utils'
+
+/**
+ * Text style props shared by {@link TableRow} and {@link TableCell}. Styles
+ * cascade: chunk-level styles (from `content`) win over cell-level ones,
+ * which win over row-level ones; the boolean attributes merge.
+ */
+export interface TableStyleProps {
+  /**
+   * Foreground color of the cell text.
+   */
+  fg?: ColorInput
+
+  /**
+   * Background color of the cell text.
+   */
+  bg?: ColorInput
+
+  /**
+   * Render the text in a bold/bright weight.
+   */
+  bold?: boolean
+
+  /**
+   * Render the text dimmed (reduced intensity).
+   */
+  dim?: boolean
+
+  /**
+   * Render the text in italics.
+   */
+  italic?: boolean
+
+  /**
+   * Underline the text.
+   */
+  underline?: boolean
+
+  /**
+   * Make the text blink. Terminal support varies.
+   */
+  blink?: boolean
+
+  /**
+   * Swap the foreground and background colors.
+   */
+  inverse?: boolean
+
+  /**
+   * Draw a line through the text.
+   */
+  strikethrough?: boolean
+}
+
+/**
+ * Props accepted by {@link TableRow}: the {@link TableStyleProps}, applied to
+ * every cell of the row (cell and chunk styles win).
+ */
+export interface TableRowProps extends TableStyleProps {}
+
+/**
+ * A table row. Only valid as a direct child of {@link TextTable}; it renders
+ * nothing by itself and only groups {@link TableCell} children.
+ */
+export const TableRow: FunctionalComponent<TableRowProps> = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    warn('[vue-termui] <TableRow> must be a direct child of <TextTable>; it renders nothing.')
+  }
+  return null
+}
+TableRow.displayName = 'TableRow'
+
+/**
+ * Props accepted by {@link TableCell}. The cell text comes from the default
+ * slot (plain strings and interpolations), or from `content` for styled runs
+ * built with the `t`/`fg`/`bold`/… helpers. The boolean style props mirror
+ * {@link Text} and are merged into each chunk; styles already present on a
+ * `content` chunk win over the cell-level ones, which win over the row-level
+ * ones.
+ */
+export interface TableCellProps extends TableStyleProps {
+  /**
+   * Styled cell content: a `StyledText` (from the `t` tag), a `TextChunk` or
+   * an array of them (from `fg()`, `bold()`, …), or a plain string. Takes
+   * precedence over the default slot.
+   */
+  content?: string | number | StyledText | TextChunk | TextChunk[]
+}
+
+/**
+ * A table cell. Only valid inside a {@link TableRow}; it renders nothing by
+ * itself — {@link TextTable} reads its props and slot to build the table
+ * content.
+ */
+export const TableCell: FunctionalComponent<TableCellProps> = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    warn('[vue-termui] <TableCell> must be a direct child of <TableRow>; it renders nothing.')
+  }
+  return null
+}
+TableCell.displayName = 'TableCell'
+
+/**
+ * Props accepted by {@link TextTable}. These are OpenTUI's native
+ * `TextTableRenderable` options and are forwarded to the underlying
+ * renderable. Instead of the `content` matrix, rows can be declared with
+ * {@link TableRow}/{@link TableCell} children.
+ *
+ * `fg`, `bg`, `backgroundColor`, `borderBackgroundColor`, `attributes`,
+ * `selectionBg` and `selectionFg` are constructor-only in OpenTUI (no
+ * setters), so they are **not reactive** — remount with a `:key` to change
+ * them.
+ */
+export interface TextTableProps extends TextTableOptions, RenderableEventProps {}
+
+/**
+ * A text table mapping to OpenTUI's `TextTableRenderable`: bordered rows and
+ * columns of (optionally styled) text with per-cell wrapping, column sizing
+ * (`columnWidthMode`, `columnFitter`) and mouse selection support.
+ *
+ * Content can be passed either as the raw `content` matrix (arrays of
+ * `TextChunk[]` built with `t`/`bold`/`fg`/…, as in OpenTUI) or declaratively
+ * with {@link TableRow} and {@link TableCell} in the default slot. The slot
+ * form is compiled into the same matrix each render; cells whose content did
+ * not change keep their identity so OpenTUI only rebuilds the cells that
+ * actually changed. When both are given, `content` wins.
+ *
+ * @example
+ * ```vue
+ * <TextTable width="100%" borderStyle="rounded">
+ *   <TableRow bold>
+ *     <TableCell>Service</TableCell>
+ *     <TableCell>Status</TableCell>
+ *   </TableRow>
+ *   <TableRow v-for="s in services" :key="s.name">
+ *     <TableCell>{{ s.name }}</TableCell>
+ *     <TableCell :fg="s.color">{{ s.status }}</TableCell>
+ *   </TableRow>
+ * </TextTable>
+ * ```
+ */
+export const TextTable: TuiComponent<TextTableProps, TextTableRenderable> = defineComponent({
+  name: 'TextTable',
+  inheritAttrs: false,
+  props: {
+    ...renderableProps,
+    content: null,
+    // kept optional so unset props preserve the renderable's defaults
+    border: null,
+    outerBorder: null,
+    showBorders: null,
+    selectable: null,
+  },
+  emits: {
+    ...renderableEmits,
+  },
+  setup(props, { emit, attrs, slots }) {
+    const table = shallowRef<TextTableRenderable | null>(null)
+
+    onMounted(() => {
+      const el = table.value
+      if (!el) return
+
+      // Common Renderable events + autofocus on mount
+      setupRenderableEvents(el, emit, props)
+    })
+
+    // Previous slot-built content, so unchanged cells keep their identity
+    // across re-renders (OpenTUI diffs cells by reference).
+    let prevContent: TextTableContent | null = null
+
+    return (): VNode => {
+      const content =
+        (props.content as TextTableContent | undefined) ??
+        (prevContent = buildTableContent(slots.default?.(), prevContent))
+
+      return h('tui-text-table', {
+        ...attrs,
+        ...optionalBooleanProps(props, [
+          'border',
+          'outerBorder',
+          'showBorders',
+          'selectable',
+          'focusable',
+        ]),
+        content,
+        ref: table,
+      })
+    }
+  },
+})
+
+/**
+ * Flattens slot results into component vnodes, unwrapping fragments (`v-for`)
+ * and dropping comments (`v-if` placeholders) and stray whitespace.
+ */
+function flattenSlotVNodes(children: VNodeArrayChildren | undefined, out: VNode[] = []): VNode[] {
+  if (!children) return out
+  for (const child of children) {
+    if (child == null || typeof child === 'boolean' || typeof child === 'string') continue
+    if (Array.isArray(child)) {
+      flattenSlotVNodes(child, out)
+    } else if (isVNode(child)) {
+      if (child.type === Fragment) {
+        flattenSlotVNodes(child.children as VNodeArrayChildren, out)
+      } else if (child.type !== Comment) {
+        out.push(child)
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Invokes a component vnode's default slot without mounting it. Raw slots
+ * (not normalized by Vue) may return a single child or even a bare string, so
+ * the result is normalized into an array.
+ */
+function defaultSlotChildren(vnode: VNode): VNodeArrayChildren {
+  const { children } = vnode
+  if (children && typeof children === 'object' && !Array.isArray(children)) {
+    const slot = (children as { default?: () => unknown }).default
+    const value = slot ? slot() : undefined
+    if (value == null) return []
+    return (Array.isArray(value) ? value : [value]) as VNodeArrayChildren
+  }
+  return []
+}
+
+/**
+ * Collects the text of a cell's default slot: raw strings/numbers and text
+ * vnodes (static text and `{{ }}` interpolations), through fragments.
+ */
+function slotText(children: unknown): string {
+  if (children == null || typeof children === 'boolean') return ''
+  if (typeof children === 'string' || typeof children === 'number') return String(children)
+  if (Array.isArray(children)) return children.map(slotText).join('')
+  if (isVNode(children)) {
+    if (children.type === TextVNode) return slotText(children.children)
+    if (children.type === Fragment) return slotText(children.children)
+    if (process.env.NODE_ENV !== 'production' && children.type !== Comment) {
+      warn(
+        `[vue-termui] <TableCell> only accepts text in its slot; use the \`content\` prop with the t/fg/bold helpers for styled runs. Ignored: ${describeVNode(children)}.`,
+      )
+    }
+  }
+  return ''
+}
+
+function describeVNode(vnode: VNode): string {
+  const { type } = vnode
+  if (typeof type === 'string') return `<${type}>`
+  if (typeof type === 'object' && type && 'name' in type && typeof type.name === 'string') {
+    return `<${type.name}>`
+  }
+  if (typeof type === 'function' && 'displayName' in type) {
+    return `<${(type as { displayName?: string }).displayName}>`
+  }
+  return String(type)
+}
+
+function colorEquals(a: RGBA | undefined, b: RGBA | undefined): boolean {
+  return a === b || (!!a && !!b && a.equals(b))
+}
+
+function chunkEquals(a: TextChunk, b: TextChunk): boolean {
+  return (
+    a.text === b.text &&
+    a.attributes === b.attributes &&
+    colorEquals(a.fg, b.fg) &&
+    colorEquals(a.bg, b.bg) &&
+    a.link?.url === b.link?.url
+  )
+}
+
+function cellEquals(a: TextTableCellContent, b: TextTableCellContent): boolean {
+  if (!a || !b) return a === b
+  return a.length === b.length && a.every((chunk, i) => chunkEquals(chunk, b[i]!))
+}
+
+/**
+ * The {@link TableStyleProps} of a row/cell vnode, resolved into chunk form:
+ * parsed colors and an attributes bitmask.
+ */
+interface ResolvedTableStyle {
+  fg: RGBA | undefined
+  bg: RGBA | undefined
+  attributes: number
+}
+
+const NO_STYLE: ResolvedTableStyle = { fg: undefined, bg: undefined, attributes: 0 }
+
+function resolveStyleProps(vnode: VNode): ResolvedTableStyle {
+  const props = (vnode.props ?? {}) as TableStyleProps
+  return {
+    fg: props.fg != null ? parseColor(props.fg) : undefined,
+    bg: props.bg != null ? parseColor(props.bg) : undefined,
+    attributes: createTextAttributes({
+      // coerce bare attributes (`<TableCell bold>` arrives as '')
+      bold: props.bold != null && props.bold !== false,
+      dim: props.dim != null && props.dim !== false,
+      italic: props.italic != null && props.italic !== false,
+      underline: props.underline != null && props.underline !== false,
+      blink: props.blink != null && props.blink !== false,
+      inverse: props.inverse != null && props.inverse !== false,
+      strikethrough: props.strikethrough != null && props.strikethrough !== false,
+    }),
+  }
+}
+
+/**
+ * Builds a cell's chunks from a {@link TableCell} vnode: `content` prop first
+ * (StyledText, chunk(s) or string), the default slot's text otherwise; then
+ * merges the cell- and row-level style props in — chunk styles win over cell
+ * styles, which win over row styles; attributes merge.
+ */
+function cellToChunks(vnode: VNode, rowStyle: ResolvedTableStyle): TextChunk[] {
+  const { content } = (vnode.props ?? {}) as TableCellProps
+
+  let chunks: TextChunk[]
+  if (content != null) {
+    if (isStyledText(content)) {
+      chunks = content.chunks
+    } else if (Array.isArray(content)) {
+      chunks = content
+    } else if (typeof content === 'object') {
+      chunks = [content]
+    } else {
+      chunks = [{ __isChunk: true, text: String(content) }]
+    }
+  } else {
+    chunks = [{ __isChunk: true, text: slotText(defaultSlotChildren(vnode)) }]
+  }
+
+  const cellStyle = resolveStyleProps(vnode)
+  const fg = cellStyle.fg ?? rowStyle.fg
+  const bg = cellStyle.bg ?? rowStyle.bg
+  const attributes = cellStyle.attributes | rowStyle.attributes
+  if (fg == null && bg == null && attributes === 0) return chunks
+
+  return chunks.map((chunk) => ({
+    __isChunk: true as const,
+    text: chunk.text,
+    fg: chunk.fg ?? fg,
+    bg: chunk.bg ?? bg,
+    attributes: (chunk.attributes ?? 0) | attributes,
+    link: chunk.link,
+  }))
+}
+
+/**
+ * Compiles `<TableRow>`/`<TableCell>` slot vnodes into OpenTUI's
+ * `TextTableContent` matrix, reusing the previous render's cell and row arrays
+ * when their chunks are unchanged so `TextTableRenderable`'s reference-based
+ * cell diff only rebuilds what changed.
+ */
+function buildTableContent(
+  children: VNodeArrayChildren | undefined,
+  prev: TextTableContent | null,
+): TextTableContent {
+  const rows: TextTableContent = []
+
+  for (const rowVNode of flattenSlotVNodes(children)) {
+    if (rowVNode.type !== TableRow) {
+      if (process.env.NODE_ENV !== 'production') {
+        warn(
+          `[vue-termui] <TextTable> only accepts <TableRow> children (wrapper components are not supported). Ignored: ${describeVNode(rowVNode)}.`,
+        )
+      }
+      continue
+    }
+
+    const prevRow = prev?.[rows.length]
+    let rowUnchanged = prevRow !== undefined
+    const cells: TextTableCellContent[] = []
+    const rowStyle = rowVNode.props ? resolveStyleProps(rowVNode) : NO_STYLE
+
+    for (const cellVNode of flattenSlotVNodes(defaultSlotChildren(rowVNode))) {
+      if (cellVNode.type !== TableCell) {
+        if (process.env.NODE_ENV !== 'production') {
+          warn(
+            `[vue-termui] <TableRow> only accepts <TableCell> children (wrapper components are not supported). Ignored: ${describeVNode(cellVNode)}.`,
+          )
+        }
+        continue
+      }
+
+      const chunks = cellToChunks(cellVNode, rowStyle)
+      const prevCell = prevRow?.[cells.length]
+      if (prevCell && cellEquals(prevCell, chunks)) {
+        cells.push(prevCell)
+      } else {
+        cells.push(chunks)
+        rowUnchanged = false
+      }
+    }
+
+    rows.push(rowUnchanged && prevRow!.length === cells.length ? prevRow! : cells)
+  }
+
+  return rows
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,4 +1,4 @@
-import type { RGBA } from '@opentui/core'
+import type { BorderStyle as OpenTUIBorderStyle, RGBA } from '@opentui/core'
 
 /**
  * A color accepted by OpenTUI: a hex/name string or an {@link RGBA} instance.
@@ -42,6 +42,9 @@ export type Position = 'static' | 'relative' | 'absolute'
 export type Overflow = 'visible' | 'hidden' | 'scroll'
 
 /**
- * Border preset understood by OpenTUI.
+ * Border preset understood by OpenTUI: `'single' | 'double' | 'rounded' |
+ * 'heavy'` (aliased so it cannot drift). There is no `'none'` style — hide
+ * borders with `border: false`, or `border`/`outerBorder`/`showBorders` on
+ * `<TextTable>`.
  */
-export type BorderStyle = 'single' | 'double' | 'rounded' | 'heavy' | 'none'
+export type BorderStyle = OpenTUIBorderStyle

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,13 @@ export { ScrollBox } from './components/ScrollBox'
 export type { ScrollBoxProps } from './components/ScrollBox'
 export { ProgressBar } from './components/ProgressBar'
 export type { ProgressBarProps } from './components/ProgressBar'
+export { TextTable, TableRow, TableCell } from './components/TextTable'
+export type {
+  TextTableProps,
+  TableRowProps,
+  TableCellProps,
+  TableStyleProps,
+} from './components/TextTable'
 export { Markdown, SyntaxStyle } from './components/Markdown'
 export type { MarkdownProps, StyleDefinitionInput } from './components/Markdown'
 export type {

--- a/src/renderer/nodeOps.ts
+++ b/src/renderer/nodeOps.ts
@@ -12,6 +12,8 @@ import {
   TextareaRenderable,
   TextNodeRenderable,
   TextRenderable,
+  TextTableRenderable,
+  type TextTableOptions,
 } from '@opentui/core'
 import type { RendererOptions } from '@vue/runtime-core'
 import { propToOptionalBoolean } from '../components/utils'
@@ -43,6 +45,7 @@ export type TuiElementTag =
   | 'tui-tab-select'
   | 'tui-markdown'
   | 'tui-scroll-box'
+  | 'tui-text-table'
 
 /**
  * Builds the Vue {@link RendererOptions} that translate Vue tree mutations into
@@ -137,6 +140,22 @@ export function createNodeOps(ctx: RenderContext): RendererOptions<BaseRenderabl
             scrollX: propToOptionalBoolean(props?.scrollX),
             scrollY: propToOptionalBoolean(props?.scrollY),
           })
+        case 'tui-text-table': {
+          // These color/attribute options are constructor-only on
+          // `TextTableRenderable` (no setters), so they must be read here
+          // instead of riding the patchProp path. `undefined` values keep the
+          // renderable's defaults.
+          const options = props as TextTableOptions | null
+          return new TextTableRenderable(ctx, {
+            fg: options?.fg,
+            bg: options?.bg,
+            backgroundColor: options?.backgroundColor,
+            borderBackgroundColor: options?.borderBackgroundColor,
+            attributes: options?.attributes,
+            selectionBg: options?.selectionBg,
+            selectionFg: options?.selectionFg,
+          })
+        }
         case 'tui-markdown': {
           // `MarkdownRenderable` requires a `syntaxStyle` up front, so read it
           // from the props here rather than deferring to patchProp. The


### PR DESCRIPTION
## What
TextTable + TableRow/TableCell components, wired in nodeOps as tui-text-table, exported types

Slot rows compile to the content matrix; unchanged cells keep identity so OpenTUI's cell diff skips them

## Implementation Notes
- fg/bg/backgroundColor/selection colors are constructor-only in OpenTUI → non-reactive, documented
- Fix: exported BorderStyle wrongly included 'none' (OpenTUI has no such style) — now aliases OpenTUI's type

## Testing
- 14 new specs; full suite 188 passing
- Demo verified live in the playground