### PR TITLE
build(three): upgrade three 0.177 → 0.180

### DIFF
--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -50,14 +50,14 @@
     "jimp": "1.6.1"
   },
   "peerDependencies": {
-    "three": "^0.178.0",
+    "three": "^0.179.1",
     "vue-termui": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/three": "0.178.0",
+    "@types/three": "0.179.0",
     "@webgpu/types": "^0.1.60",
-    "three": "0.178.0",
+    "three": "0.179.1",
     "tsdown": "^0.22.7",
     "typescript": "~6.0.3",
     "vue-termui": "workspace:*"

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -50,14 +50,14 @@
     "jimp": "1.6.1"
   },
   "peerDependencies": {
-    "three": "^0.177.0",
+    "three": "^0.178.0",
     "vue-termui": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/three": "0.177.0",
+    "@types/three": "0.178.0",
     "@webgpu/types": "^0.1.60",
-    "three": "0.177.0",
+    "three": "0.178.0",
     "tsdown": "^0.22.7",
     "typescript": "~6.0.3",
     "vue-termui": "workspace:*"

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -50,14 +50,14 @@
     "jimp": "1.6.1"
   },
   "peerDependencies": {
-    "three": "^0.179.1",
+    "three": "^0.180.0",
     "vue-termui": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/three": "0.179.0",
+    "@types/three": "0.180.0",
     "@webgpu/types": "^0.1.60",
-    "three": "0.179.1",
+    "three": "0.180.0",
     "tsdown": "^0.22.7",
     "typescript": "~6.0.3",
     "vue-termui": "workspace:*"

--- a/packages/three/src/animation/SpriteParticleGenerator.ts
+++ b/packages/three/src/animation/SpriteParticleGenerator.ts
@@ -18,7 +18,8 @@ import {
   floor,
   mod,
 } from 'three/tsl'
-import { MeshBasicNodeMaterial, NodeMaterial } from 'three/webgpu'
+import { MeshBasicNodeMaterial, NodeMaterial, type Node } from 'three/webgpu'
+import type { ShaderNodeObject } from 'three/tsl'
 import type { SpriteResource, InstanceManager } from '../SpriteResourceManager'
 
 export interface ParticleEffectParameters {
@@ -206,7 +207,10 @@ export class SpriteParticleGenerator {
     const cosZ = cos(rotationAmount.z)
     const sinZ = sin(rotationAmount.z)
 
-    const rotationMatrix = mat3(
+    // @types/three types mat3() only for 9 numbers or a single node, but the
+    // runtime builds a JoinNode from 9 node args. Widen the signature to match.
+    const mat3n = mat3 as unknown as (...args: Node[]) => ShaderNodeObject<Node>
+    const rotationMatrix = mat3n(
       cosY.mul(cosZ),
       cosY.mul(sinZ).negate(),
       sinY,
@@ -229,7 +233,7 @@ export class SpriteParticleGenerator {
     const scaledPosition = rotatedVertexPosition.mul(currentScale)
     const finalPosition = scaledPosition.add(currentPosition)
 
-    let opacity = float(1.0)
+    let opacity: ShaderNodeObject<Node> = float(1.0)
     if (this.baseConfig.fadeOut) {
       const fadeStart = float(0.7)
       const fadeProgress = max(

--- a/packages/three/src/webgpu.spec.ts
+++ b/packages/three/src/webgpu.spec.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { installBrowserGlobals } from './webgpu'
+
+describe('installBrowserGlobals', () => {
+  it('stubs browser globals three/webgpu references unguarded in Node', () => {
+    installBrowserGlobals()
+
+    // three 0.180 Textures.getSize runs `image instanceof VideoFrame` for
+    // every texture, and NodeSampler.setupUV runs `texture.image instanceof
+    // ImageBitmap`; neither is guarded with a typeof check, so both globals
+    // must exist or the render loop throws a ReferenceError in Node.
+    expect(typeof VideoFrame).toBe('function')
+    expect(typeof ImageBitmap).toBe('function')
+
+    // our textures are never real VideoFrame/ImageBitmap instances, so the
+    // stubbed checks resolve to false instead of throwing.
+    expect(({} as unknown) instanceof VideoFrame).toBe(false)
+    expect(({} as unknown) instanceof ImageBitmap).toBe(false)
+  })
+})

--- a/packages/three/src/webgpu.ts
+++ b/packages/three/src/webgpu.ts
@@ -17,6 +17,28 @@ export function loadWebGPU(): Promise<WebGPUModule> {
   return webgpuModule
 }
 
+/**
+ * Installs the browser globals three/webgpu expects but Node lacks. Idempotent
+ * (only fills globals that are still undefined) and free of native
+ * dependencies, so it is safe to call before the GPU device exists.
+ */
+export function installBrowserGlobals(): void {
+  const g = globalThis as Record<string, unknown>
+  // three's internal Animation loop drives itself with
+  // `self.requestAnimationFrame`; Bun has both globals, Node has neither.
+  // The timers are unref'd so an idle loop never keeps the process alive.
+  g.self ??= globalThis
+  g.requestAnimationFrame ??= (callback: (time: number) => void) =>
+    setTimeout(() => callback(performance.now()), 16).unref()
+  g.cancelAnimationFrame ??= (id: NodeJS.Timeout) => clearTimeout(id)
+  // three references these WebCodecs/DOM types in unguarded `instanceof`
+  // checks (Textures.getSize on VideoFrame for every texture, since 0.180;
+  // NodeSampler.setupUV on ImageBitmap). Our images are never such instances,
+  // so empty-class stubs make the checks resolve to false instead of throwing.
+  g.VideoFrame ??= class VideoFrame {}
+  g.ImageBitmap ??= class ImageBitmap {}
+}
+
 let globalsReady: Promise<WebGPUModule> | undefined
 
 /**
@@ -37,14 +59,7 @@ export function setupWebGPU(libPath?: string): Promise<WebGPUModule> {
         configurable: true,
       })
     }
-    // three's internal Animation loop drives itself with
-    // `self.requestAnimationFrame`; Bun has both globals, Node has neither.
-    // The timers are unref'd so an idle loop never keeps the process alive.
-    const g = globalThis as Record<string, unknown>
-    g.self ??= globalThis
-    g.requestAnimationFrame ??= (callback: (time: number) => void) =>
-      setTimeout(() => callback(performance.now()), 16).unref()
-    g.cancelAnimationFrame ??= (id: NodeJS.Timeout) => clearTimeout(id)
+    installBrowserGlobals()
     await webgpu.setupGlobals({ libPath })
     return webgpu
   }))

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,7 +13,7 @@
     "@opentui/core": "^0.4.3",
     "@tresjs/core": "^5.8.3",
     "@vue-termui/three": "workspace:*",
-    "three": "0.177.0",
+    "three": "0.178.0",
     "vue-router": "^5.1.0",
     "vue-termui": "workspace:*"
   },

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,7 +13,7 @@
     "@opentui/core": "^0.4.3",
     "@tresjs/core": "^5.8.3",
     "@vue-termui/three": "workspace:*",
-    "three": "0.179.1",
+    "three": "0.180.0",
     "vue-router": "^5.1.0",
     "vue-termui": "workspace:*"
   },

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,7 +13,7 @@
     "@opentui/core": "^0.4.3",
     "@tresjs/core": "^5.8.3",
     "@vue-termui/three": "workspace:*",
-    "three": "0.178.0",
+    "three": "0.179.1",
     "vue-router": "^5.1.0",
     "vue-termui": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,14 +131,14 @@ importers:
         specifier: ^26.1.1
         version: 26.1.1
       '@types/three':
-        specifier: 0.179.0
-        version: 0.179.0
+        specifier: 0.180.0
+        version: 0.180.0
       '@webgpu/types':
         specifier: ^0.1.60
         version: 0.1.71
       three:
-        specifier: 0.179.1
-        version: 0.179.1
+        specifier: 0.180.0
+        version: 0.180.0
       tsdown:
         specifier: ^0.22.7
         version: 0.22.7(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(vue-tsc@3.3.7(typescript@6.0.3))
@@ -156,13 +156,13 @@ importers:
         version: 0.4.3(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@tresjs/core':
         specifier: ^5.8.3
-        version: 5.8.3(three@0.179.1)(vue@3.5.39(typescript@6.0.3))
+        version: 5.8.3(three@0.180.0)(vue@3.5.39(typescript@6.0.3))
       '@vue-termui/three':
         specifier: workspace:*
         version: link:../packages/three
       three:
-        specifier: 0.179.1
-        version: 0.179.1
+        specifier: 0.180.0
+        version: 0.180.0
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.39)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
@@ -1580,8 +1580,8 @@ packages:
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
-  '@types/three@0.179.0':
-    resolution: {integrity: sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==}
+  '@types/three@0.180.0':
+    resolution: {integrity: sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2980,8 +2980,8 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
-  three@0.179.1:
-    resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
+  three@0.180.0:
+    resolution: {integrity: sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4451,13 +4451,13 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tresjs/core@5.8.3(three@0.179.1)(vue@3.5.39(typescript@6.0.3))':
+  '@tresjs/core@5.8.3(three@0.180.0)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@pmndrs/pointer-events': 6.6.30
       '@vue/devtools-api': 8.1.3
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
       radashi: 12.9.1
-      three: 0.179.1
+      three: 0.180.0
       vue: 3.5.39(typescript@6.0.3)
 
   '@tweenjs/tween.js@23.1.3': {}
@@ -4505,7 +4505,7 @@ snapshots:
 
   '@types/stats.js@0.17.4': {}
 
-  '@types/three@0.179.0':
+  '@types/three@0.180.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3
@@ -5952,7 +5952,7 @@ snapshots:
 
   tabbable@6.5.0: {}
 
-  three@0.179.1: {}
+  three@0.180.0: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,14 +131,14 @@ importers:
         specifier: ^26.1.1
         version: 26.1.1
       '@types/three':
-        specifier: 0.178.0
-        version: 0.178.0
+        specifier: 0.179.0
+        version: 0.179.0
       '@webgpu/types':
         specifier: ^0.1.60
         version: 0.1.71
       three:
-        specifier: 0.178.0
-        version: 0.178.0
+        specifier: 0.179.1
+        version: 0.179.1
       tsdown:
         specifier: ^0.22.7
         version: 0.22.7(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(vue-tsc@3.3.7(typescript@6.0.3))
@@ -156,13 +156,13 @@ importers:
         version: 0.4.3(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@tresjs/core':
         specifier: ^5.8.3
-        version: 5.8.3(three@0.178.0)(vue@3.5.39(typescript@6.0.3))
+        version: 5.8.3(three@0.179.1)(vue@3.5.39(typescript@6.0.3))
       '@vue-termui/three':
         specifier: workspace:*
         version: link:../packages/three
       three:
-        specifier: 0.178.0
-        version: 0.178.0
+        specifier: 0.179.1
+        version: 0.179.1
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.39)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
@@ -1580,8 +1580,8 @@ packages:
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
-  '@types/three@0.178.0':
-    resolution: {integrity: sha512-1IpVbMKbEAAWjyn0VTdVcNvI1h1NlTv3CcnwMr3NNBv/gi3PL0/EsWROnXUEkXBxl94MH5bZvS8h0WnBRmR/pQ==}
+  '@types/three@0.179.0':
+    resolution: {integrity: sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2572,8 +2572,8 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
-  meshoptimizer@0.18.1:
-    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+  meshoptimizer@0.22.0:
+    resolution: {integrity: sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -2980,8 +2980,8 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
-  three@0.178.0:
-    resolution: {integrity: sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==}
+  three@0.179.1:
+    resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4451,13 +4451,13 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tresjs/core@5.8.3(three@0.178.0)(vue@3.5.39(typescript@6.0.3))':
+  '@tresjs/core@5.8.3(three@0.179.1)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@pmndrs/pointer-events': 6.6.30
       '@vue/devtools-api': 8.1.3
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
       radashi: 12.9.1
-      three: 0.178.0
+      three: 0.179.1
       vue: 3.5.39(typescript@6.0.3)
 
   '@tweenjs/tween.js@23.1.3': {}
@@ -4505,7 +4505,7 @@ snapshots:
 
   '@types/stats.js@0.17.4': {}
 
-  '@types/three@0.178.0':
+  '@types/three@0.179.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3
@@ -4513,7 +4513,7 @@ snapshots:
       '@types/webxr': 0.5.24
       '@webgpu/types': 0.1.71
       fflate: 0.8.3
-      meshoptimizer: 0.18.1
+      meshoptimizer: 0.22.0
 
   '@types/unist@3.0.3': {}
 
@@ -5501,7 +5501,7 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  meshoptimizer@0.18.1: {}
+  meshoptimizer@0.22.0: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -5952,7 +5952,7 @@ snapshots:
 
   tabbable@6.5.0: {}
 
-  three@0.178.0: {}
+  three@0.179.1: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,14 +131,14 @@ importers:
         specifier: ^26.1.1
         version: 26.1.1
       '@types/three':
-        specifier: 0.177.0
-        version: 0.177.0
+        specifier: 0.178.0
+        version: 0.178.0
       '@webgpu/types':
         specifier: ^0.1.60
         version: 0.1.71
       three:
-        specifier: 0.177.0
-        version: 0.177.0
+        specifier: 0.178.0
+        version: 0.178.0
       tsdown:
         specifier: ^0.22.7
         version: 0.22.7(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(vue-tsc@3.3.7(typescript@6.0.3))
@@ -156,13 +156,13 @@ importers:
         version: 0.4.3(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@tresjs/core':
         specifier: ^5.8.3
-        version: 5.8.3(three@0.177.0)(vue@3.5.39(typescript@6.0.3))
+        version: 5.8.3(three@0.178.0)(vue@3.5.39(typescript@6.0.3))
       '@vue-termui/three':
         specifier: workspace:*
         version: link:../packages/three
       three:
-        specifier: 0.177.0
-        version: 0.177.0
+        specifier: 0.178.0
+        version: 0.178.0
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.39)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
@@ -1580,8 +1580,8 @@ packages:
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
-  '@types/three@0.177.0':
-    resolution: {integrity: sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==}
+  '@types/three@0.178.0':
+    resolution: {integrity: sha512-1IpVbMKbEAAWjyn0VTdVcNvI1h1NlTv3CcnwMr3NNBv/gi3PL0/EsWROnXUEkXBxl94MH5bZvS8h0WnBRmR/pQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2980,8 +2980,8 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
-  three@0.177.0:
-    resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
+  three@0.178.0:
+    resolution: {integrity: sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4451,13 +4451,13 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tresjs/core@5.8.3(three@0.177.0)(vue@3.5.39(typescript@6.0.3))':
+  '@tresjs/core@5.8.3(three@0.178.0)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@pmndrs/pointer-events': 6.6.30
       '@vue/devtools-api': 8.1.3
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
       radashi: 12.9.1
-      three: 0.177.0
+      three: 0.178.0
       vue: 3.5.39(typescript@6.0.3)
 
   '@tweenjs/tween.js@23.1.3': {}
@@ -4505,7 +4505,7 @@ snapshots:
 
   '@types/stats.js@0.17.4': {}
 
-  '@types/three@0.177.0':
+  '@types/three@0.178.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3
@@ -5952,7 +5952,7 @@ snapshots:
 
   tabbable@6.5.0: {}
 
-  three@0.177.0: {}
+  three@0.178.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
Progressively upgrades `three` from 0.177.0 to 0.180.0, one minor at a time, keeping tests + typecheck + both builds green at each step.

## Steps
- **0.178.0** — the 0.178 `@types/three` overhaul replaced the permissive `ConvertType` with strict per-function interfaces, breaking `SpriteParticleGenerator.ts`:
  - `mat3(...9 node args)` no longer types (only 9 `number`s or a single `Node`), though the runtime builds a `JoinNode`. Widened via a node-accepting alias.
  - `float()` now returns a narrow `ConstNode<number>`, so `let opacity = float(1)` then reassigning `.sub()`/`.mul()` (→ `OperatorNode`) failed. Annotated as `ShaderNodeObject<Node>`.
  - Caught only by `tsc --build` (`test:types`) — vitest's inline typecheck covers test files only.
- **0.179.1** — bump only (`@types/three@0.179.0`, no 0.179.1 types published).
- **0.180.0** — bump + a **runtime** fix (below).

## Runtime fix (VideoFrame / ImageBitmap)
three 0.180 added an **unguarded** `image instanceof VideoFrame` to `Textures.getSize`, which runs for every texture → `ReferenceError: VideoFrame is not defined` in Node (types pass; the playground crashes on first render). `NodeSampler.setupUV` has the same unguarded pattern on `ImageBitmap` (latent since 0.177, only reached under `isFlipY`). `bun-webgpu`'s `setupGlobals` installs only `GPU*`.

Extracted the pure DOM shims into `installBrowserGlobals()` and added empty-class stubs so both checks resolve to `false` instead of throwing. Added a regression test.

## Verification
- `pnpm run test:types` clean; `vitest run packages/three` → 20 tests pass (incl. new regression test); lint + fmt clean.
- `@vue-termui/three` and `playground` both build.
- Prod playground booted headlessly: `/demos/texture` renders the crate (PhongNodeMaterial + emissive — the `getSize` path) and `/demos/sprite-particles` renders 107 live particles (exercises the `SpriteParticleGenerator` TSL code). Zero `VideoFrame`/`ReferenceError` in output.

Note: `@tresjs/core`'s pre-existing `THREE.Timer` import warning at build is actually gone at 0.180.